### PR TITLE
Fix gitignore to stop ignoring all JSON

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,6 @@ pnpm-debug.log*
 # jetbrains setting folder
 .idea/
 
-# local AWS scratch
-*.json
+# local AWS scratch files
+aws-*.json
 


### PR DESCRIPTION
## Summary
- update `.gitignore` so it only ignores AWS scratch JSON files

## Testing
- `npm test` *(fails: Missing script `test`)*