### PR TITLE
Rewrite README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,47 +1,34 @@
-# Astro Starter Kit: Minimal
+# Remote IT Help Site
 
-```sh
-npm create astro@latest -- --template minimal
+This repository contains the source for **Remote IT Help**, the landing page clients use to start a secure remote support session with IT Help San Diego. The site is built with [Astro](https://astro.build/) and styled with Tailwind CSS.
+
+The main page instructs users to run a one‑line command that downloads a helper script and opens a screen‑sharing session. No tracking or session data is stored on the server.
+
+## Development
+
+```bash
+npm install
+npm run dev
 ```
 
-[![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/withastro/astro/tree/latest/examples/minimal)
-[![Open with CodeSandbox](https://assets.codesandbox.io/github/button-edit-lime.svg)](https://codesandbox.io/p/sandbox/github/withastro/astro/tree/latest/examples/minimal)
-[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/withastro/astro?devcontainer_path=.devcontainer/minimal/devcontainer.json)
+Running `npm run dev` starts the local development server on `http://localhost:4321`.
 
-> 🧑‍🚀 **Seasoned astronaut?** Delete this file. Have fun!
+## Building
 
-## 🚀 Project Structure
+To generate the static site, run:
 
-Inside of your Astro project, you'll see the following folders and files:
-
-```text
-/
-├── public/
-├── src/
-│   └── pages/
-│       └── index.astro
-└── package.json
+```bash
+npm run build
 ```
 
-Astro looks for `.astro` or `.md` files in the `src/pages/` directory. Each page is exposed as a route based on its file name.
+The output is written to the `dist` directory.
 
-There's nothing special about `src/components/`, but that's where we like to put any Astro/React/Vue/Svelte/Preact components.
+## Deployment
 
-Any static assets, like images, can be placed in the `public/` directory.
+Deployments are handled automatically via GitHub Actions. Commits pushed to the `main` branch trigger the `deploy` workflow, which:
 
-## 🧞 Commands
+1. Builds the site with `npm run build`.
+2. Syncs the contents of `dist` to the S3 bucket `remote-it-help.com`.
+3. Invalidates the associated CloudFront distribution so changes go live immediately.
 
-All commands are run from the root of the project, from a terminal:
-
-| Command                   | Action                                           |
-| :------------------------ | :----------------------------------------------- |
-| `npm install`             | Installs dependencies                            |
-| `npm run dev`             | Starts local dev server at `localhost:4321`      |
-| `npm run build`           | Build your production site to `./dist/`          |
-| `npm run preview`         | Preview your build locally, before deploying     |
-| `npm run astro ...`       | Run CLI commands like `astro add`, `astro check` |
-| `npm run astro -- --help` | Get help using the Astro CLI                     |
-
-## 👀 Want to learn more?
-
-Feel free to check [our documentation](https://docs.astro.build) or jump into our [Discord server](https://astro.build/chat).
+You can also serve the built site with any static hosting service by uploading the `dist` directory.


### PR DESCRIPTION
## Summary
- document the remote support site
- add steps to build and deploy

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build` *(fails: astro not found due to missing dependencies)*