### PR TITLE
Remove unused font face

### DIFF
--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -13,13 +13,6 @@ export const title = 'Remote IT Help';
     <title>{title}</title>
     <link rel="icon" href="/favicon.svg" />
 
-    <!-- tiny 2 KB self-hosted mono font -->
-    <style>
-      @font-face {
-        font-family: 'CascadiaMono';
-        src: url('/CascadiaMono.woff2') format('woff2');
-      }
-    </style>
   </head>
 
   <body class="min-h-screen bg-gray-900 text-gray-100 font-sans antialiased">


### PR DESCRIPTION
## Summary
- remove the Cascadia Mono `@font-face` block from `Base.astro`

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build` *(fails: astro not found)*