### PR TITLE
Clean up dark mode assets and styles

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -15,7 +15,6 @@
   <body>
     <header>
       <h1>{{ site.title }}</h1>
-      <button id="mode-toggle">Toggle Dark Mode</button>
       <nav>
         <ul>
           <li><a href="/">Home</a></li>
@@ -31,6 +30,5 @@
     <footer>
       <p>Copyright © {{ site.time | date: '%Y' }}</p>
     </footer>
-    <script src="/assets/js/darkmode.js"></script>
   </body>
 </html>

--- a/_sass/_darkmode.scss
+++ b/_sass/_darkmode.scss
@@ -1,4 +1,5 @@
 /* _darkmode.scss */
+body {
   background-color: #333; /* Dark gray background */
   color: #ffffff;
   font-family: Arial, sans-serif;
@@ -6,6 +7,31 @@
   padding: 0;
 }
 
+a {
+  color: #BB86FC;
+}
+
+header,
+footer {
+  background-color: #444; /* Slightly lighter dark background for header/footer */
+  color: #ffffff;
+  padding: 1em;
+}
+
+nav ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+nav li {
+  display: inline-block;
+  margin-right: 15px;
+}
+
+nav a {
+  text-decoration: none;
+  color: #BB86FC;
 }
 
 @media (max-width: 600px) {
@@ -14,11 +40,6 @@
     flex-direction: column;
     align-items: center;
     padding-left: 0;
-  }
-
-  #mode-toggle {
-    position: static;
-    margin-top: 10px;
   }
 }
 

--- a/assets/css/darkmode.css
+++ b/assets/css/darkmode.css
@@ -1,4 +1,5 @@
 /* darkmode.css */
+body {
   background-color: #333; /* Dark gray background */
   color: #ffffff; /* White text */
   font-family: Arial, sans-serif;
@@ -6,11 +7,31 @@
   padding: 0;
 }
 
-body.dark-mode a {
+a {
   color: #BB86FC; /* Light purple link color */
 }
 
+header,
+footer {
+  background-color: #444; /* Slightly lighter dark background for header/footer */
+  color: #ffffff;
+  padding: 1em;
+}
 
+nav ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+nav li {
+  display: inline-block;
+  margin-right: 15px;
+}
+
+nav a {
+  text-decoration: none;
+  color: #BB86FC;
 }
 
 @media (max-width: 600px) {
@@ -20,7 +41,6 @@ body.dark-mode a {
     align-items: center;
     padding-left: 0;
   }
-
 }
 
 /* Additional dark theme styles can be added here */

--- a/assets/js/darkmode.js
+++ b/assets/js/darkmode.js
@@ -1,7 +1,0 @@
-document.addEventListener('DOMContentLoaded', function () {
-  var toggle = document.getElementById('mode-toggle');
-  if (!toggle) return;
-  toggle.addEventListener('click', function () {
-    document.body.classList.toggle('dark-mode');
-  });
-});


### PR DESCRIPTION
## Summary
- drop dark mode toggle button from layout
- remove dark mode script reference
- simplify dark mode styles so they apply directly to the page
- delete unused `darkmode.js`

## Testing
- `bundle exec jekyll build` *(fails: bundler not installed)*