### PR TITLE
Fix dark theme and remove unused toggle script

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -14,10 +14,9 @@
     <header>
       <h1>{{ site.title }}</h1>
       <nav>
-        <ul>
-          <li><a href="/">Home</a></li>
-          <li><a href="/about">About</a></li>
-        </ul>
+          <ul>
+            <li><a href="/">Home</a></li>
+          </ul>
       </nav>
     </header>
 

--- a/_sass/_custom.scss
+++ b/_sass/_custom.scss
@@ -3,6 +3,7 @@ header {
   display: flex;
   flex-direction: column;
   align-items: center;
+  margin-bottom: 1em;
 }
 
 nav ul {

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -1,5 +1,7 @@
-@use 'darkmode';
-@use "jekyll-theme-minimal";
-@use "fonts";
-@use "rouge-github";
-@use "custom";
+---
+---
+
+// Import the default theme first so our overrides apply afterwards
+@import "jekyll-theme-minimal";
+@import "darkmode";
+@import "custom";

--- a/assets/js/darkmode.js
+++ b/assets/js/darkmode.js
@@ -1,7 +1,0 @@
-document.addEventListener('DOMContentLoaded', function () {
-  const toggle = document.getElementById('mode-toggle');
-  if (!toggle) return;
-  toggle.addEventListener('click', function () {
-    document.body.classList.toggle('dark-mode');
-  });
-});


### PR DESCRIPTION
## Summary
- add YAML front matter so `style.scss` compiles
- switch to `@import` directives and drop missing partials
- remove unused About link and dark‑mode script

## Testing
- `bundle exec jekyll build` *(fails: command not found)*