### PR TITLE
Remove unused about link

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -16,7 +16,6 @@
       <nav>
         <ul>
           <li><a href="/">Home</a></li>
-          <li><a href="/about">About</a></li>
         </ul>
       </nav>
     </header>


### PR DESCRIPTION
## Summary
- remove the About link in the default layout

## Testing
- `bundle exec jekyll build` *(fails: bundler: command not found: jekyll)*
- `bundle install` *(fails: Could not fetch specs from https://rubygems.org/)*