### PR TITLE
Improve header layout responsiveness

### DIFF
--- a/_sass/_custom.scss
+++ b/_sass/_custom.scss
@@ -1,7 +1,18 @@
 /* Custom styles */
 header {
   display: flex;
+  justify-content: space-between;
   align-items: center;
+  flex-wrap: wrap;
+  margin-bottom: 1.5rem;
+}
+
+nav ul {
+  display: flex;
+  gap: 1rem;
+  list-style: none;
+  padding: 0;
+  margin: 0;
 }
 
 .cta-button {
@@ -15,17 +26,22 @@ header {
 }
 
 main {
-
 }
 
-.cta-button {
-  display: inline-block;
-  background-color: #BB86FC;
-  color: #000;
-  padding: 0.5em 1em;
-  border-radius: 4px;
-  text-decoration: none;
-  margin-top: 0.5em;
+main h1:first-child {
+  margin-top: 0;
+}
+
+@media (max-width: 600px) {
+  header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  nav ul {
+    flex-direction: column;
+    gap: 0.5rem;
+  }
 }
 
 /* Mode toggle placeholder - ensure no absolute positioning if present */


### PR DESCRIPTION
## Summary
- tweak header with flex layout to wrap and add bottom spacing
- style nav with flex and spacing between links
- stack header items on small screens
- remove duplicate CTA styles and tidy main heading spacing

## Testing
- `bundle exec jekyll build` *(fails: jekyll not installed)*
- `bundle install` *(fails: no network access to fetch gems)*