### PR TITLE
Add services page and header CTA

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -6,7 +6,7 @@
     <title>{{ page.title }}</title>
 
     <!-- Link to main stylesheet -->
-    <link rel="stylesheet" href="/assets/css/style.css">
+    <link rel="stylesheet" href="{{ '/assets/css/style.css' | relative_url }}">
     
   </head>
 
@@ -15,9 +15,11 @@
       <h1>{{ site.title }}</h1>
       <nav>
         <ul>
-          <li><a href="/">Home</a></li>
+          <li><a href="{{ '/' | relative_url }}">Home</a></li>
+          <li><a href="{{ '/services/' | relative_url }}">Services</a></li>
         </ul>
       </nav>
+      <a href="https://schedule.it-help.tech/" class="cta-button">Book now</a>
     </header>
 
     <main>

--- a/_sass/_custom.scss
+++ b/_sass/_custom.scss
@@ -1,17 +1,57 @@
 /* Custom styles */
 header {
   display: flex;
-  flex-direction: column;
+  justify-content: space-between;
   align-items: center;
+  flex-wrap: wrap;
+  gap: 1em;
+  padding-bottom: 1em;
   margin-bottom: 1em;
 }
 
+header h1 {
+  margin: 0;
+  font-size: 1.75em;
+}
+
 nav ul {
-  margin-top: 0.5em; /* space below the title */
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  gap: 1em;
 }
 
 nav li {
-  margin: 0 0.5em;
+  margin: 0;
+}
+
+main {
+  padding-top: 0;
+}
+
+main h1:first-child {
+  margin-top: 0;
+}
+
+.cta-button {
+  display: inline-block;
+  background-color: #BB86FC;
+  color: #000;
+  padding: 0.5em 1em;
+  border-radius: 4px;
+  text-decoration: none;
+}
+
+@media (max-width: 600px) {
+  header {
+    flex-direction: column;
+  }
+
+  nav ul {
+    flex-direction: column;
+    align-items: center;
+  }
 }
 
 /* Mode toggle placeholder - ensure no absolute positioning if present */

--- a/services.md
+++ b/services.md
@@ -1,0 +1,17 @@
+---
+layout: default
+title: Services
+---
+
+# Our Services
+
+We offer a range of IT support solutions to keep your business running smoothly.
+
+- Email migration and setup
+- DNS and domain management
+- Advanced email deliverability troubleshooting
+- Security compliance and DMARC implementations
+- Mac mail configuration and support
+- Website and domain recovery
+
+Need help right away? [Book now](https://schedule.it-help.tech/).


### PR DESCRIPTION
## Summary
- add Services link and call-to-action button to header
- create new `services.md` page
- tweak custom styles so header doesn't overlap content and style the CTA button
- use relative URLs for stylesheet and navigation links

## Testing
- `bundle exec jekyll build` *(fails: bundler: command not found)*