### PR TITLE
Fix nav services link

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -16,7 +16,7 @@
       <nav>
         <ul>
           <li><a href="{{ '/' | relative_url }}">Home</a></li>
-          main
+          <li><a href="{{ '/services/' | relative_url }}">Services</a></li>
         </ul>
       </nav>
       <a href="https://schedule.it-help.tech/" class="cta-button">Book now</a>


### PR DESCRIPTION
## Summary
- add missing Services link in navigation
- ensure stylesheet uses `relative_url`

## Testing
- `bundle exec jekyll build` *(fails: bundler command not found)*