### PR TITLE
Adjust permalink style

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -17,7 +17,7 @@ kramdown:
 # Use default style so each page outputs as a single HTML file
 # in the site root instead of within its own directory
 # This keeps the deployed structure simple (e.g., services.html)
-# permalink: pretty
+permalink: /:name.html
 
 # Exclude files from the final build (e.g., any markdown files not to be processed)
 exclude:


### PR DESCRIPTION
## Summary
- ensure generated pages appear at the site root by setting global permalink style

## Testing
- `bundle install` *(fails: Could not fetch specs from https://rubygems.org/)*
- `jekyll build` *(fails: command not found)*