### PR TITLE
Fix header layout and services link

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -14,7 +14,7 @@ kramdown:
   input: GFM
 
 # Permalink settings (optional, based on your structure)
-permalink: pretty
+permalink: /:name.html
 
 # Exclude files from the final build (e.g., any markdown files not to be processed)
 exclude:

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -6,7 +6,7 @@
     <title>{{ page.title }}</title>
 
     <!-- Link to main stylesheet -->
-    <link rel="stylesheet" href="/assets/css/style.css">
+  <link rel="stylesheet" href="{{ '/assets/css/style.css' | relative_url }}">
     
   </head>
 
@@ -15,9 +15,11 @@
       <h1>{{ site.title }}</h1>
       <nav>
         <ul>
-          <li><a href="/">Home</a></li>
+          <li><a href="{{ '/' | relative_url }}">Home</a></li>
+          <li><a href="{{ '/services.html' | relative_url }}">Services</a></li>
         </ul>
       </nav>
+      <a href="https://schedule.it-help.tech/" class="cta-button">Book now</a>
     </header>
 
     <main>

--- a/_sass/_custom.scss
+++ b/_sass/_custom.scss
@@ -1,17 +1,58 @@
 /* Custom styles */
 header {
   display: flex;
-  flex-direction: column;
+  justify-content: space-between;
   align-items: center;
-  margin-bottom: 1em;
+  flex-wrap: wrap;
+  gap: 1rem;
+  margin-bottom: 1.5em;
+  position: relative; /* ensure header does not overlap content */
 }
 
 nav ul {
-  margin-top: 0.5em; /* space below the title */
+  display: flex;
+  gap: 1rem;
+  list-style: none;
+  padding: 0;
+  margin: 0;
 }
 
 nav li {
-  margin: 0 0.5em;
+  margin: 0;
+}
+
+main {
+  padding-top: 1em; /* space below the header */
+}
+
+main h1:first-child {
+  margin-top: 0;
+}
+
+.cta-button {
+  display: inline-block;
+  background-color: #BB86FC;
+  color: #000;
+  padding: 0.5em 1em;
+  border-radius: 4px;
+  text-decoration: none;
+  margin-top: 0.5em;
+}
+
+@media (max-width: 600px) {
+  header {
+    flex-direction: column;
+    align-items: center;
+  }
+
+  nav ul {
+    flex-direction: column;
+    gap: 0.5rem;
+  }
+
+  .cta-button {
+    margin-top: 1rem;
+  }
 }
 
 /* Mode toggle placeholder - ensure no absolute positioning if present */

--- a/services.md
+++ b/services.md
@@ -1,0 +1,18 @@
+---
+layout: default
+title: Services
+permalink: /services.html
+---
+
+# Our Services
+
+We offer a range of IT support solutions to keep your business running smoothly.
+
+- Email migration and setup
+- DNS and domain management
+- Advanced email deliverability troubleshooting
+- Security compliance and DMARC implementations
+- Mac mail configuration and support
+- Website and domain recovery
+
+Need help right away? [Book now](https://schedule.it-help.tech/).


### PR DESCRIPTION
## Summary
- keep generated pages at site root
- ensure stylesheet and nav links work with base URL
- redesign header flexbox for better spacing
- link to services page as `/services.html`

## Testing
- `bundle exec jekyll build` *(fails: bundler: command not found)*