### PR TITLE
Improve header spacing

### DIFF
--- a/_sass/_custom.scss
+++ b/_sass/_custom.scss
@@ -4,10 +4,13 @@ header {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  flex-wrap: wrap;
   gap: 1rem;
-  padding-bottom: 1rem;
-  margin-bottom: 1rem;
+  padding-bottom: 2rem;
+  margin-bottom: 2rem;
+}
+
+header h1 {
+  margin: 0;
 }
 
 nav ul {


### PR DESCRIPTION
## Summary
- tweak header flexbox styles for consistent spacing
- add bottom padding and margin to header
- normalize header title margin

## Testing
- `bundle exec jekyll build` *(fails: bundler couldn't access rubygems)*