### PR TITLE
Refine header layout and dark styles

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>{{ page.title }}</title>
+    <title>{{ page.title }} | {{ site.title }}</title>
 
     <!-- Link to main stylesheet -->
     <link rel="stylesheet" href="{{ '/assets/css/style.css' | relative_url }}">
@@ -11,7 +11,7 @@
   </head>
 
   <body>
-    <header>
+    <header class="container">
       <h1>{{ site.title }}</h1>
       <nav>
         <ul>
@@ -22,11 +22,11 @@
       <a href="https://schedule.it-help.tech/" class="cta-button">Book now</a>
     </header>
 
-    <main>
+    <main class="container">
       {{ content }}
     </main>
 
-    <footer>
+    <footer class="container">
       <p>Copyright © {{ site.time | date: '%Y' }}</p>
     </footer>
   </body>

--- a/_sass/_custom.scss
+++ b/_sass/_custom.scss
@@ -1,12 +1,14 @@
 /* Custom styles */
 
 header {
+  position: static;
   display: flex;
+  flex-wrap: wrap;
   justify-content: space-between;
   align-items: center;
   gap: 1rem;
-  padding-bottom: 2rem;
-  margin-bottom: 2rem;
+  padding: 0.5rem 0;
+  margin-bottom: 1rem;
 }
 
 header h1 {
@@ -15,10 +17,19 @@ header h1 {
 
 nav ul {
   display: flex;
+  flex-wrap: wrap;
   list-style: none;
   padding: 0;
   margin: 0;
   gap: 1rem;
+}
+
+nav a {
+  padding: 0.25rem 0.75rem;
+  border-radius: 4px;
+  text-decoration: none;
+  background-color: #2b2b2b;
+  color: #e0e0e0;
 }
 
 main h1:first-child {
@@ -50,7 +61,9 @@ main h1:first-child {
   }
 }
 
-/* Mode toggle placeholder - ensure no absolute positioning if present */
-#mode-toggle {
-  position: static;
+
+.container {
+  width: 90%;
+  max-width: 900px;
+  margin: 0 auto;
 }

--- a/_sass/_darkmode.scss
+++ b/_sass/_darkmode.scss
@@ -1,21 +1,35 @@
 /* _darkmode.scss */
+*, *::before, *::after {
+  box-sizing: border-box;
+}
+
 body {
-  background-color: #333; /* Dark gray background */
-  color: #ffffff;
-  font-family: Arial, sans-serif;
+  background-color: #121212;
+  color: #e0e0e0;
+  font-family: "Courier New", monospace;
   margin: 0;
   padding: 0;
 }
 
 a {
-  color: #BB86FC;
+  color: #8ab4f8;
 }
 
 header,
 footer {
-  background-color: #444; /* Slightly lighter dark background for header/footer */
-  color: #ffffff;
-  padding: 1em;
+  background-color: transparent;
+  color: #e0e0e0;
+  padding: 1rem 0;
+  border-color: #333;
+}
+
+header {
+  border-bottom: 1px solid var(--header-border, #333);
+}
+
+footer {
+  border-top: 1px solid var(--footer-border, #333);
+  margin-top: 2rem;
 }
 
 nav ul {
@@ -26,13 +40,14 @@ nav ul {
 
 nav li {
   display: inline-block;
-  margin-right: 15px;
+  margin-right: 1rem;
 }
 
 nav a {
   text-decoration: none;
-  color: #BB86FC;
+  color: #8ab4f8;
 }
+
 
 @media (max-width: 600px) {
   nav ul {


### PR DESCRIPTION
## Summary
- adjust header padding and make position static
- style nav links as small buttons
- remove unused mode-toggle rules and consolidate container class
- make header/footer transparent with border accents

## Testing
- `bundle install`
- `bundle exec jekyll build`
