### PR TITLE
Remove duplicate container style

### DIFF
--- a/_sass/_darkmode.scss
+++ b/_sass/_darkmode.scss
@@ -38,11 +38,6 @@ nav a {
   color: #8ab4f8;
 }
 
-.container {
-  width: 90%;
-  max-width: 900px;
-  margin: 0 auto;
-}
 
 @media (max-width: 600px) {
   nav ul {


### PR DESCRIPTION
## Summary
- remove duplicate `.container` definition from darkmode styles
- rebuild Jekyll site to regenerate CSS

## Testing
- `jekyll build`
