### PR TITLE
Remove unused mode toggle

### DIFF
--- a/_sass/_custom.scss
+++ b/_sass/_custom.scss
@@ -53,10 +53,6 @@ main h1:first-child {
   }
 }
 
-/* Mode toggle placeholder - ensure no absolute positioning if present */
-#mode-toggle {
-  position: static;
-}
 
 .container {
   width: 90%;


### PR DESCRIPTION
## Summary
- delete the `#mode-toggle` CSS rule that has no matching HTML or script

## Testing
- `bundle exec jekyll build`