### PR TITLE
Add cross-domain canonical tag

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -4,6 +4,7 @@ description: "Get expert, on-demand remote IT support nationwide. We specialize 
 logo: /assets/images/logo-blue.png
 baseurl: ""
 url: "https://remote-it-help.com"
+canonical_base: "https://www.it-help.tech"
 
 theme: jekyll-theme-minimal
 highlighter: rouge

--- a/_plugins/canonical_hook.rb
+++ b/_plugins/canonical_hook.rb
@@ -1,0 +1,33 @@
+canonical_base = Jekyll.configuration({})['canonical_base']
+
+Jekyll::Hooks.register :pages, :pre_render do |page|
+  base = page.site.config['canonical_base'] || page.site.config['url']
+  canonical_url = File.join(base, page.url.to_s)
+  canonical_url = canonical_url.sub(/index\.html$/, '/')
+  page.data['canonical_url'] = canonical_url
+end
+
+Jekyll::Hooks.register :documents, :pre_render do |doc|
+  base = doc.site.config['canonical_base'] || doc.site.config['url']
+  canonical_url = File.join(base, doc.url.to_s)
+  canonical_url = canonical_url.sub(/index\.html$/, '/')
+  doc.data['canonical_url'] = canonical_url
+end
+
+require 'addressable/uri'
+
+module Jekyll
+  class SeoTag
+    class Drop
+      alias_method :original_canonical_url, :canonical_url
+      def canonical_url
+        base = site['canonical_base'] || site['url']
+        if page['canonical_url'].to_s.empty?
+          Addressable::URI.join(base, page['url']).to_s.gsub(%r!/index\.html$!, '/')
+        else
+          page['canonical_url']
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- set `canonical_base` in config
- add plugin to override jekyll-seo-tag canonical URLs

## Testing
- `bundle exec jekyll build --quiet`

------
https://chatgpt.com/codex/tasks/task_e_685af733c6a48329b912f738d7231cad